### PR TITLE
Minor Bugfix in Example Code for StackedAreaChart in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ class StackedAreaExample extends React.PureComponent {
         const keys   = [ 'apples', 'bananas', 'cherries', 'dates' ]
 
         return (
-            <AreaStackChart
+            <StackedAreaChart
                 style={ { height: 200, paddingVertical: 16 } }
                 data={ data }
                 keys={ keys }


### PR DESCRIPTION
Greetings!

I came across a minor bug in the example for StackedAreaChart in the readme:

```
import { StackedAreaChart } from 'react-native-svg-charts'
----- SNIP ---
        return (
            <AreaStackChart
```

See the mismatch?  I went ahead and updated the documentation so that we use the StackedAreaChart in both places.

Thanks for the library!