### PR TITLE
PieChart example fixed on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ class PieChartExample extends React.PureComponent {
         return (
             <PieChart
                 style={ { height: 200 } }
-                dataPoints={ pieData }
+                data={ pieData }
             />
         )
     }


### PR DESCRIPTION
Simple change, the README.md says that the ```data``` props is required, but only ```dataPoints``` is passed. When executing this, the message that ```dataPoints``` has been "renamed" to ```data``` is shown.