### PR TITLE
Fix PieChat example

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,8 +407,8 @@ class PieChartExample extends React.PureComponent {
             .filter(value => value > 0)
             .map((value, index) => ({
                 value,
+                color: randomColor(),
                 svg: {
-                    fill: randomColor(),
                     onPress: () => console.log('press', index),
                 },
                 key: `pie-${index}`,


### PR DESCRIPTION
The PieChart requires color attributes, and it will throw warning and not properly colored if not provided