### PR TITLE
Implement ability to configure svgs ordering

### DIFF
--- a/storybook/stories/index.js
+++ b/storybook/stories/index.js
@@ -44,6 +44,8 @@ import CustomGrid from './custom-grid'
 import PartialAreaChart from './partial-chart/area-chart'
 import PartialLineChart from './partial-chart/line-chart'
 
+import OrderExample from './order';
+
 storiesOf('AreaChart', module)
     .addDecorator(getStory => <ShowcaseCard>{ getStory() }</ShowcaseCard>)
     .add('Standard', () => <AreaChart/>)
@@ -95,3 +97,4 @@ storiesOf('Others', module)
     .add('Custom Grid', () => <CustomGrid/>)
     .add('Partial Area Chart', () => <PartialAreaChart/>)
     .add('Partial Line Chart', () => <PartialLineChart/>)
+    .add('Ordering', () => <OrderExample/>)

--- a/storybook/stories/order/index.js
+++ b/storybook/stories/order/index.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { AreaChart } from 'react-native-svg-charts'
+import * as shape from 'd3-shape'
+import { Text, View } from 'react-native';
+
+class OrderExample extends React.PureComponent {
+
+    render() {
+
+        const data = [ 50, 10, 40, 95, -4, -24, 85, 91, 35, 53, -53, 24, 50, -20, -80 ]
+
+        return (
+          <View>
+            <Text>grid on top of chart (default)</Text>
+            <AreaChart
+                style={{ height: 200 }}
+                data={ data }
+                contentInset={{ top: 30, bottom: 30 }}
+                curve={ shape.curveNatural }
+                svg={{ fill: 'rgba(134, 65, 244, 1)' }}
+            />
+            <Text>grid underneath chart</Text>
+            <AreaChart
+                style={{ height: 200 }}
+                data={ data }
+                contentInset={{ top: 30, bottom: 30 }}
+                curve={ shape.curveNatural }
+                svg={{ fill: 'rgba(134, 65, 244, 1)' }}
+                renderOrder={() => ['grid', 'chart', 'decorators', 'extras']}
+            />
+          </View>
+        );
+    }
+}
+
+export default OrderExample


### PR DESCRIPTION
As discussed in ticket #101, opening a PR containing chart/grid/decorators/extras ordering possibility implementation. Tested all stories on my side locally, order story added.