### PR TITLE
YAxis, XAxis  add children props , like gradient

### DIFF
--- a/src/x-axis.js
+++ b/src/x-axis.js
@@ -60,7 +60,7 @@ class XAxis extends PureComponent {
             formatLabel,
             numberOfTicks,
             svg,
-            children
+            children,
         } = this.props
 
         const { width } = this.state

--- a/src/x-axis.js
+++ b/src/x-axis.js
@@ -60,6 +60,7 @@ class XAxis extends PureComponent {
             formatLabel,
             numberOfTicks,
             svg,
+            children
         } = this.props
 
         const { width } = this.state
@@ -86,6 +87,7 @@ class XAxis extends PureComponent {
                         { formatLabel(ticks[0], 0) }
                     </Text>
                     <Svg style={ StyleSheet.absoluteFill }>
+                        {children}
                         {
                             // don't render labels if width isn't measured yet,
                             // causes rendering issues

--- a/src/y-axis.js
+++ b/src/y-axis.js
@@ -62,7 +62,7 @@ class YAxis extends PureComponent {
             min,
             max,
             svg,
-            children
+            children,
         } = this.props
 
         const { height } = this.state

--- a/src/y-axis.js
+++ b/src/y-axis.js
@@ -62,6 +62,7 @@ class YAxis extends PureComponent {
             min,
             max,
             svg,
+            children
         } = this.props
 
         const { height } = this.state
@@ -99,6 +100,7 @@ class YAxis extends PureComponent {
                         {longestValue}
                     </Text>
                     <Svg style={ StyleSheet.absoluteFill }>
+                        {children}
                         {
                             // don't render labels if width isn't measured yet,
                             // causes rendering issues


### PR DESCRIPTION

<img width="241" alt="qq20180413-102931 2x" src="https://user-images.githubusercontent.com/10494442/38713791-9a853e64-3f05-11e8-82e4-2797735d4934.png">

Used: 

        const axesSvg = {fontSize: 10, fill: 'url(#gradient)'};
         <YAxis
                    data={data}
                    numberOfTicks={5}
                    style={{marginRight: 15, marginBottom: 24}}
                    contentInset={verticalContentInset}
                    svg={axesSvg}
                >
                    <Defs key={'gradient'}>
                        <LinearGradient id={'gradient'} x1={'0'} y={'0%'} x2={'100%'} y2={'0%'}>
                            <Stop offset={'0%'} stopColor={'rgb(108,193,190)'}/>
                            <Stop offset={'100%'} stopColor={'rgb(133,227,169)'}/>
                        </LinearGradient>
                    </Defs>
                </YAxis>
