### PR TITLE
Fix issue with pie charts and rendering on react-native-web

### DIFF
--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -122,7 +122,7 @@ class PieChart extends PureComponent {
                     style={{ flex: 1 }}
                     onLayout={ event => this._onLayout(event) }
                 >
-                    <Svg style={{ flex: 1 }}>
+                    <Svg style={{ width: this.state.width, height: this.state.height }}>
                         {/* center the progress circle*/}
                         <G
                             x={ width / 2 }


### PR DESCRIPTION
We use react-native-web to render full cross platform apps (iOS, Android and Web).  When using this library (along with a webpack alias to the svgs library), we found a really small change that makes a world of difference.  On Pie Charts, the SVG element is rendered inside a flaxbox which has already set the state's width/height when the onLayout callback is triggered.  If we switch to using that width/height instead of flex on the SVG component itself, everything is happy, even when the window is resized.  This change has no effect on the iOS and Android components.

Thanks