### PR TITLE
Clone React element only if child is not `null`

### DIFF
--- a/src/bar-chart/bar-chart.js
+++ b/src/bar-chart/bar-chart.js
@@ -173,7 +173,7 @@ class BarChart extends PureComponent {
                         <Svg style={{ height, width }}>
                             {
                                 React.Children.map(children, child => {
-                                    if(child.props.belowChart) {
+                                    if(child && child.props.belowChart) {
                                         return React.cloneElement(child, extraProps)
                                     }
                                 })
@@ -197,7 +197,7 @@ class BarChart extends PureComponent {
                             }
                             {
                                 React.Children.map(children, child => {
-                                    if(!child.props.belowChart) {
+                                    if(child && !child.props.belowChart) {
                                         return React.cloneElement(child, extraProps)
                                     }
                                 })

--- a/src/chart.js
+++ b/src/chart.js
@@ -99,7 +99,7 @@ class Chart extends PureComponent {
                         <Svg style={{ height, width }}>
                             {
                                 React.Children.map(children, child => {
-                                    if (child.props.belowChart) {
+                                    if (child && child.props.belowChart) {
                                         return React.cloneElement(child, extraProps)
                                     }
                                     return null
@@ -114,7 +114,7 @@ class Chart extends PureComponent {
                             />
                             {
                                 React.Children.map(children, child => {
-                                    if (!child.props.belowChart) {
+                                    if (child && !child.props.belowChart) {
                                         return React.cloneElement(child, extraProps)
                                     }
                                     return null

--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -132,7 +132,7 @@ class PieChart extends PureComponent {
                             >
                                 {
                                     React.Children.map(children, child => {
-                                        if (child.props.belowChart) {
+                                        if (child && child.props.belowChart) {
                                             return React.cloneElement(child, extraProps)
                                         }
                                         return null
@@ -153,7 +153,7 @@ class PieChart extends PureComponent {
                                 })}
                                 {
                                     React.Children.map(children, child => {
-                                        if (!child.props.belowChart) {
+                                        if (child && !child.props.belowChart) {
                                             return React.cloneElement(child, extraProps)
                                         }
                                         return null

--- a/src/progress-circle.js
+++ b/src/progress-circle.js
@@ -97,7 +97,7 @@ class ProgressCircle extends PureComponent {
                         >
                             {
                                 React.Children.map(children, child => {
-                                    if (child.props.belowChart) {
+                                    if (child && child.props.belowChart) {
                                         return React.cloneElement(child, extraProps)
                                     }
                                     return null
@@ -116,7 +116,7 @@ class ProgressCircle extends PureComponent {
                             })}
                             {
                                 React.Children.map(children, child => {
-                                    if (!child.props.belowChart) {
+                                    if (child && !child.props.belowChart) {
                                         return React.cloneElement(child, extraProps)
                                     }
                                     return null

--- a/src/stacked-area-chart.js
+++ b/src/stacked-area-chart.js
@@ -116,7 +116,7 @@ class AreaStack extends PureComponent {
                         <Svg style={{ height, width }}>
                             {
                                 React.Children.map(children, child => {
-                                    if (child.props.belowChart) {
+                                    if (child && child.props.belowChart) {
                                         return React.cloneElement(child, extraProps)
                                     }
                                     return null
@@ -147,7 +147,7 @@ class AreaStack extends PureComponent {
                             )}
                             {
                                 React.Children.map(children, child => {
-                                    if (!child.props.belowChart) {
+                                    if (child && !child.props.belowChart) {
                                         return React.cloneElement(child, extraProps)
                                     }
                                     return null

--- a/src/stacked-bar-chart.js
+++ b/src/stacked-bar-chart.js
@@ -184,7 +184,7 @@ class BarChart extends PureComponent {
                         <Svg style={{ height, width }}>
                             {
                                 React.Children.map(children, child => {
-                                    if (child.props.belowChart) {
+                                    if (child && child.props.belowChart) {
                                         return React.cloneElement(child, extraProps)
                                     }
                                     return null
@@ -211,7 +211,7 @@ class BarChart extends PureComponent {
                             })}
                             {
                                 React.Children.map(children, child => {
-                                    if (!child.props.belowChart) {
+                                    if (child && !child.props.belowChart) {
                                         return React.cloneElement(child, extraProps)
                                     }
                                     return null


### PR DESCRIPTION
Fixes case for adding children of the chart with confition, e.g. when
`showGrid` is `false`, JSX passes a `null` child:

```
const Graph = ({ showGrid }) => {
  const { showGrid } = props

  return (
    <AreaChart
      style={{ height: 200 }}
      data={ data }
      contentInset={{ top: 30, bottom: 30 }}
      curve={ shape.curveNatural }
      svg={{ fill: 'rgba(134, 65, 244, 0.8)' }}
    >
      {showGrid && <Grid/>}
    </AreaChart>
  )
}
```