### PR TITLE
Update chart.js

### DIFF
--- a/src/chart.js
+++ b/src/chart.js
@@ -132,6 +132,7 @@ Chart.propTypes = {
     data: PropTypes.oneOfType([
         PropTypes.arrayOf(PropTypes.object),
         PropTypes.arrayOf(PropTypes.number),
+        PropTypes.arrayOf(PropTypes.array),
     ]).isRequired,
     svg: PropTypes.object,
 


### PR DESCRIPTION
Supporting 2-dimensional data arrays, in addition to the 1-d arrays and json objects. This works as it stands, but gives a type warning.