### PR TITLE
Grouped Stacked Bars

### DIFF
--- a/src/bar-chart/bar-chart-grouped.js
+++ b/src/bar-chart/bar-chart-grouped.js
@@ -145,8 +145,8 @@ class GroupedBarChart extends BarChart {
         const extent = array.extent([ ...dataExtent, gridMax, gridMin ])
 
         const {
-            yMin = extent[ 0 ],
-            yMax = extent[ 1 ],
+            yMin = extent[0],
+            yMax = extent[1],
         } = this.props
 
         return [ yMin, yMax ]
@@ -154,7 +154,7 @@ class GroupedBarChart extends BarChart {
 
     calcIndexes() {
         const { data } = this.props
-        return data[ 0 ].data.map((_, index) => index)
+        return data[0].data.map((_, index) => index)
     }
 }
 

--- a/src/stacked-bar-chart/index.js
+++ b/src/stacked-bar-chart/index.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import StackedBarChart from './stacked-bar-chart'
+import StackedBarChartGrouped from './stacked-bar-grouped'
+
+const StackedBarChartGate = props => {
+    const { data } = props
+
+    if (data[0].hasOwnProperty('data')) {
+        return <StackedBarChartGrouped { ...props } />
+    }
+
+    return <StackedBarChart { ...props } />
+}
+
+export default StackedBarChartGate

--- a/src/stacked-bar-chart/stacked-bar-grouped.js
+++ b/src/stacked-bar-chart/stacked-bar-grouped.js
@@ -1,0 +1,281 @@
+import React, { PureComponent } from 'react'
+import { View } from 'react-native'
+import PropTypes from 'prop-types'
+import Svg from 'react-native-svg'
+import * as array from 'd3-array'
+import * as scale from 'd3-scale'
+import * as shape from 'd3-shape'
+import Path from '../animated-path'
+
+class StackedBarGrouped extends PureComponent {
+    state = {
+        width: 0,
+        height: 0,
+    }
+
+    _onLayout(event) {
+        const { nativeEvent: { layout: { height, width } } } = event
+        this.setState({ height, width })
+    }
+
+    calcXScale(domain) {
+        const { horizontal, contentInset: { left = 0, right = 0 }, spacingInner, spacingOuter } = this.props
+
+        const { width } = this.state
+
+        if (horizontal) {
+            return scale
+                .scaleLinear()
+                .domain(domain)
+                .range([ left, width - right ])
+        }
+
+        return scale
+            .scaleBand()
+            .domain(domain)
+            .range([ left, width - right ])
+            .paddingInner([ spacingInner ])
+            .paddingOuter([ spacingOuter ])
+    }
+
+    calcYScale(domain) {
+        const { horizontal, contentInset: { top = 0, bottom = 0 }, spacingInner, spacingOuter } = this.props
+
+        const { height } = this.state
+
+        if (horizontal) {
+            return scale
+                .scaleBand()
+                .domain(domain)
+                .range([ top, height - bottom ])
+                .paddingInner([ spacingInner ])
+                .paddingOuter([ spacingOuter ])
+        }
+
+        return scale
+            .scaleLinear()
+            .domain(domain)
+            .range([ height - bottom, top ])
+    }
+
+    calcAreas(x, y, series) {
+        const { horizontal, colors, keys, data } = this.props
+        let areas
+        let barWidth
+
+        if (horizontal) {
+            barWidth = y.bandwidth() / data.length
+
+            areas = series.map((stack, stackIndex) => {
+                return stack.map((serie, keyIndex) => {
+                    return serie.map((entry, entryIndex) => {
+                        const path = shape
+                            .area()
+                            .x0(d => x(d[0]))
+                            .x1(d => x(d[1]))
+                            .y((d, _index) => (_index === 0 ?
+                                y(entryIndex) + (barWidth * stackIndex) :
+                                y(entryIndex) + barWidth + (barWidth * stackIndex)))
+                            .defined(d => !isNaN(d[0]) && !isNaN(d[1]))([ entry, entry ])
+
+                        return {
+                            path,
+                            color: colors[stackIndex][keyIndex],
+                            key: keys[stackIndex][keyIndex],
+                        }
+                    })
+                })
+            })
+        } else {
+            barWidth = x.bandwidth() / data.length
+
+            areas = series.map((stack, stackIndex) => {
+                return stack.map((serie, keyIndex) => {
+                    return serie.map((entry, entryIndex) => {
+                        const path = shape
+                            .area()
+                            .y0(d => y(d[0]))
+                            .y1(d => y(d[1]))
+                            .x((d, _index) => (_index === 0 ?
+                                x(entryIndex) + (barWidth * stackIndex) :
+                                x(entryIndex) + barWidth + (barWidth * stackIndex))
+                            )
+                            .defined(d => !isNaN(d[0]) && !isNaN(d[1]))([ entry, entry ])
+
+                        return {
+                            path,
+                            color: colors[stackIndex][keyIndex],
+                            key: keys[stackIndex][keyIndex],
+                        }
+                    })
+                })
+            })
+        }
+
+        return array.merge(areas)
+    }
+
+    calcExtent(values) {
+        const {
+            gridMax,
+            gridMin,
+        } = this.props
+
+        // One more merge for stacked groups
+        const mergedValues = array.merge(values)
+
+        return array.extent([ ...mergedValues, gridMin, gridMax ])
+    }
+
+    calcIndexes() {
+        const { data } = this.props
+
+        // Must return an array with indexes for the number of groups to be shown
+        return data[0].data.map((_, index) => index)
+    }
+
+    getSeries() {
+        const { data, keys, offset, order, valueAccessor } = this.props
+
+        return data.map((obj, index) => shape
+            .stack()
+            .keys(keys[index])
+            .value((item, key) => valueAccessor({ item, key }))
+            .order(order)
+            .offset(offset)(obj.data))
+    }
+
+    render() {
+        const {
+            data,
+            animate,
+            animationDuration,
+            style,
+            numberOfTicks,
+            children,
+            horizontal,
+        } = this.props
+
+        const { height, width } = this.state
+
+        if (data.length === 0) {
+            return <View style={ style } />
+        }
+
+        const series = this.getSeries()
+
+        //double merge arrays to extract just the values
+        const values = array.merge(array.merge(series))
+        const indexes = this.calcIndexes(values)
+
+        const extent = this.calcExtent(values)
+        const ticks = array.ticks(extent[0], extent[1], numberOfTicks)
+
+        const xDomain = horizontal ? extent : indexes
+        const yDomain = horizontal ? indexes : extent
+
+        const x = this.calcXScale(xDomain)
+        const y = this.calcYScale(yDomain)
+
+        const stacks = this.calcAreas(x, y, series)
+
+        const extraProps = {
+            x,
+            y,
+            width,
+            height,
+            ticks,
+            data,
+        }
+
+        return (
+            <View style={ style }>
+                <View style={{ flex: 1 }} onLayout={ event => this._onLayout(event) }>
+                    {
+                        height > 0 && width > 0 &&
+                        <Svg style={{ height, width }}>
+                            {
+                                React.Children.map(children, child => {
+                                    if (child && child.props.belowChart) {
+                                        return React.cloneElement(child, extraProps)
+                                    }
+                                    return null
+                                })
+                            }
+                            {
+                                stacks.map((areas, indexStack) => {
+                                    const areaIndex = indexStack % data.length
+
+                                    return areas.map((bar, indexArea) => {
+                                        const keyIndex = indexArea % data[areaIndex].data.length
+                                        const key = `${areaIndex}-${keyIndex}-${bar.key}`
+
+                                        const { svg } = data[areaIndex].data[keyIndex][bar.key]
+
+                                        return (
+                                            <Path
+                                                key={ key }
+                                                fill={ bar.color }
+                                                { ...svg }
+                                                d={ bar.path }
+                                                animate={ animate }
+                                                animationDuration={ animationDuration }
+                                            />
+                                        )
+                                    })
+                                })
+
+                            }
+                            {
+                                React.Children.map(children, child => {
+                                    if (child && !child.props.belowChart) {
+                                        return React.cloneElement(child, extraProps)
+                                    }
+                                    return null
+                                })
+                            }
+                        </Svg>
+                    }
+                </View>
+            </View>
+        )
+    }
+}
+
+StackedBarGrouped.propTypes = {
+    data: PropTypes.arrayOf(PropTypes.object),
+    keys: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired,
+    colors: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired,
+    offset: PropTypes.func,
+    order: PropTypes.func,
+    style: PropTypes.any,
+    spacingInner: PropTypes.number,
+    spacingOuter: PropTypes.number,
+    animate: PropTypes.bool,
+    animationDuration: PropTypes.number,
+    contentInset: PropTypes.shape({
+        top: PropTypes.number,
+        left: PropTypes.number,
+        right: PropTypes.number,
+        bottom: PropTypes.number,
+    }),
+    gridMin: PropTypes.number,
+    gridMax: PropTypes.number,
+    valueAccessor: PropTypes.func,
+}
+
+StackedBarGrouped.defaultProps = {
+    spacingInner: 0.05,
+    spacingOuter: 0.05,
+    offset: shape.stackOffsetNone,
+    order: shape.stackOrderNone,
+    width: 100,
+    height: 100,
+    showZeroAxis: true,
+    contentInset: {},
+    numberOfTicks: 10,
+    showGrid: true,
+    valueAccessor: ({ item, key }) => item[key],
+}
+
+export default StackedBarGrouped

--- a/storybook/stories/bar-stack/grouped.js
+++ b/storybook/stories/bar-stack/grouped.js
@@ -1,0 +1,132 @@
+import React from 'react'
+import { StackedBarChart, Grid } from 'react-native-svg-charts'
+
+class StackedBarChartExample extends React.PureComponent {
+    render() {
+        const data = [
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 400,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 600,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 400,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 400,
+                        oranges: 200,
+                    }],
+            },
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 400,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 600,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 400,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 400,
+                        oranges: 200,
+                    }],
+            },
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 400,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 600,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 400,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 400,
+                        oranges: 2500,
+                    }],
+            },
+        ]
+
+        const colors = [[ '#8800cc', '#aa00ff' ], [ '#dd99ff', '#cc66ff' ], [ '#eeccff' ]]
+        const keys = [[ 'apples', 'bananas' ], [ 'cherries', 'dates' ], [ 'oranges' ]]
+
+        return (
+            <StackedBarChart
+                style={{ height: 200 }}
+                keys={ keys }
+                colors={ colors }
+                data={ data }
+                showGrid={ false }
+                contentInset={{ top: 30, bottom: 30 }}
+            >
+                <Grid />
+            </StackedBarChart >
+        )
+    }
+}
+
+export default StackedBarChartExample

--- a/storybook/stories/bar-stack/horizontal-grouped.js
+++ b/storybook/stories/bar-stack/horizontal-grouped.js
@@ -1,0 +1,133 @@
+import React from 'react'
+import { StackedBarChart, Grid } from 'react-native-svg-charts'
+
+class StackedBarChartExample extends React.PureComponent {
+    render() {
+        const data = [
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 1240,
+                        oranges: 4780,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 3240,
+                        oranges: 3300,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 1900,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 650,
+                        oranges: 2000,
+                    }],
+            },
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 1240,
+                        oranges: 4780,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 3240,
+                        oranges: 3300,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 1900,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 650,
+                        oranges: 2000,
+                    }],
+            },
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 1240,
+                        oranges: 4780,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 3240,
+                        oranges: 3300,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 1900,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 650,
+                        oranges: 2000,
+                    }],
+            },
+        ]
+
+        const colors = [[ '#8800cc', '#aa00ff', '#dd99ff' ], [ '#cc66ff' ], [ '#eeccff' ]]
+        const keys = [[ 'apples', 'cherries', 'bananas' ], [ 'dates' ], [ 'oranges' ]]
+
+        return (
+            <StackedBarChart
+                style={{ height: 200 }}
+                keys={ keys }
+                colors={ colors }
+                data={ data }
+                showGrid={ false }
+                contentInset={{ top: 30, bottom: 30 }}
+                horizontal
+            >
+                <Grid direction={ Grid.Direction.VERTICAL } />
+            </StackedBarChart >
+        )
+    }
+}
+
+export default StackedBarChartExample

--- a/storybook/stories/bar-stack/index.js
+++ b/storybook/stories/bar-stack/index.js
@@ -4,10 +4,14 @@ import { storiesOf } from '@storybook/react-native'
 import Standard from './standard'
 import Horizontal from './horizontal'
 import WithOnPress from './with-on-press'
+import Grouped from './grouped'
+import HorizontalGrouped from './horizontal-grouped'
 import ShowcaseCard from '../showcase-card'
 
 storiesOf('BarStack', module)
-    .addDecorator(getStory => <ShowcaseCard>{ getStory() }</ShowcaseCard>)
-    .add('Standard', () => <Standard/>)
-    .add('Horizontal', () => <Horizontal/>)
-    .add('With onPress', () => <WithOnPress/>)
+    .addDecorator(getStory => <ShowcaseCard>{getStory()}</ShowcaseCard>)
+    .add('Standard', () => <Standard />)
+    .add('Horizontal', () => <Horizontal />)
+    .add('With onPress', () => <WithOnPress />)
+    .add('Grouped', () => <Grouped />)
+    .add('Horizontal - grouped', () => <HorizontalGrouped />)


### PR DESCRIPTION
Adds the ability to group stacked bar charts and normal bar charts (a stacked bar chart with only one key) referenced in #196.

To accomplish this I followed the example of the grouped bar chart but did not wind up extending StackedBarChart.  I had initially set out to extend, but wound up overriding everything in the end.

Stories were added for grouped stacked bars in vertical and horizontal configurations.