### PR TITLE
Feature  y-axis TextAnchor prop

### DIFF
--- a/src/y-axis.js
+++ b/src/y-axis.js
@@ -62,6 +62,7 @@ class YAxis extends PureComponent {
             formatLabel,
             svg,
             children,
+            textAnchor,
         } = this.props
 
         const { height, width } = this.state
@@ -92,6 +93,8 @@ class YAxis extends PureComponent {
             .map((value, index) => formatLabel(value, index))
             .reduce((prev, curr) => prev.toString().length > curr.toString().length ? prev : curr, 0)
 
+        const x = textAnchor === 'middle' ? '50%' : 0;
+            
         return (
             <View style={ [ style ] }>
                 <View
@@ -122,8 +125,8 @@ class YAxis extends PureComponent {
                                     return (
                                         <SVGText
                                             originY={ y(value) }
-                                            textAnchor={ 'middle' }
-                                            x={ '50%' }
+                                            textAnchor={ textAnchor }
+                                            x={ x }
                                             alignmentBaseline={ 'middle' }
                                             { ...svg }
                                             key={ index }
@@ -161,6 +164,7 @@ YAxis.propTypes = {
     scale: PropTypes.func,
     spacingInner: PropTypes.number,
     spacingOuter: PropTypes.number,
+	textAnchor: PropTypes.oneOf(['middle', 'left']),
 }
 
 YAxis.defaultProps = {
@@ -172,6 +176,7 @@ YAxis.defaultProps = {
     scale: d3Scale.scaleLinear,
     formatLabel: value => value && value.toString(),
     yAccessor: ({ item }) => item,
+    textAnchor: 'middle',
 }
 
 export default YAxis

--- a/src/y-axis.js
+++ b/src/y-axis.js
@@ -93,7 +93,7 @@ class YAxis extends PureComponent {
             .map((value, index) => formatLabel(value, index))
             .reduce((prev, curr) => prev.toString().length > curr.toString().length ? prev : curr, 0)
 
-        const x = textAnchor === 'middle' ? '50%' : 0;
+        const x = textAnchor === 'middle' ? '50%' : 0
             
         return (
             <View style={ [ style ] }>
@@ -164,7 +164,7 @@ YAxis.propTypes = {
     scale: PropTypes.func,
     spacingInner: PropTypes.number,
     spacingOuter: PropTypes.number,
-	textAnchor: PropTypes.oneOf(['middle', 'left']),
+    textAnchor: PropTypes.oneOf([ 'middle', 'left' ]),
 }
 
 YAxis.defaultProps = {

--- a/storybook/stories/y-axis/standard.js
+++ b/storybook/stories/y-axis/standard.js
@@ -19,7 +19,7 @@ class YAxisExample extends React.PureComponent {
                         fill: 'grey',
                         fontSize: 10,
                     }}
-                    textAnchor={'middle'}
+                    textAnchor={ 'middle' }
                     numberOfTicks={ 10 }
                     formatLabel={ value => `${value}ºC` }
                 />

--- a/storybook/stories/y-axis/standard.js
+++ b/storybook/stories/y-axis/standard.js
@@ -19,6 +19,7 @@ class YAxisExample extends React.PureComponent {
                         fill: 'grey',
                         fontSize: 10,
                     }}
+                    textAnchor={'middle'}
                     numberOfTicks={ 10 }
                     formatLabel={ value => `${value}ºC` }
                 />


### PR DESCRIPTION
I have added the ability to change the `textAnchor` within the `SVGText` for the `YAxis` component. I have done this because I have come across needing to align my labels as they are not all the same width. 

With the labels being forced into the `middle` it makes it not look so clean, but aligning to the `left` works well. Here's some examples:

Default (`middle`):
<img width="559" alt="middle" src="https://user-images.githubusercontent.com/6137789/43253854-d454eafe-90bd-11e8-8208-162ede0b1f12.png">

`left`:
<img width="559" alt="left" src="https://user-images.githubusercontent.com/6137789/43253858-d62b4774-90bd-11e8-9caa-679a97d061e7.png">


Thanks!