### PR TITLE
Feature/grouped line charts

### DIFF
--- a/src/area-chart.js
+++ b/src/area-chart.js
@@ -1,6 +1,6 @@
 import * as shape from 'd3-shape'
 import PropTypes from 'prop-types'
-import Chart from './chart'
+import Chart from './chart/chart'
 
 class AreaChart extends Chart {
 

--- a/src/bar-chart/bar-chart-grouped.js
+++ b/src/bar-chart/bar-chart-grouped.js
@@ -145,8 +145,8 @@ class GroupedBarChart extends BarChart {
         const extent = array.extent([ ...dataExtent, gridMax, gridMin ])
 
         const {
-            yMin = extent[ 0 ],
-            yMax = extent[ 1 ],
+            yMin = extent[0],
+            yMax = extent[1],
         } = this.props
 
         return [ yMin, yMax ]
@@ -154,7 +154,7 @@ class GroupedBarChart extends BarChart {
 
     calcIndexes() {
         const { data } = this.props
-        return data[ 0 ].data.map((_, index) => index)
+        return data[0].data.map((_, index) => index)
     }
 }
 

--- a/src/chart/chart-grouped.js
+++ b/src/chart/chart-grouped.js
@@ -1,6 +1,4 @@
 import * as array from 'd3-array'
-// import * as scale from 'd3-scale'
-// import * as shape from 'd3-shape'
 import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'
 import { View } from 'react-native'

--- a/src/chart/chart.js
+++ b/src/chart/chart.js
@@ -1,0 +1,194 @@
+import * as array from 'd3-array'
+import * as scale from 'd3-scale'
+import * as shape from 'd3-shape'
+import PropTypes from 'prop-types'
+import React, { PureComponent } from 'react'
+import { View } from 'react-native'
+import Svg from 'react-native-svg'
+import Path from '../animated-path'
+
+class Chart extends PureComponent {
+
+    state = {
+        width: 0,
+        height: 0,
+    }
+
+    _onLayout(event) {
+        const { nativeEvent: { layout: { height, width } } } = event
+        this.setState({ height, width })
+    }
+
+    createPaths() {
+        throw 'Extending "Chart" requires you to override "createPaths'
+    }
+
+    render() {
+
+        const {
+            data,
+            xAccessor,
+            yAccessor,
+            yScale,
+            xScale,
+            style,
+            animate,
+            animationDuration,
+            numberOfTicks,
+            contentInset: {
+                top = 0,
+                bottom = 0,
+                left = 0,
+                right = 0,
+            },
+            gridMax,
+            gridMin,
+            clampX,
+            clampY,
+            svg,
+            children,
+        } = this.props
+
+        const { width, height } = this.state
+
+        if (data.length === 0) {
+            return <View style={ style }/>
+        }
+
+        const mappedData = data.map((item, index) => ({
+            y: yAccessor({ item, index }),
+            x: xAccessor({ item, index }),
+        }))
+
+        const yValues = mappedData.map(item => item.y)
+        const xValues = mappedData.map(item => item.x)
+
+        const yExtent = array.extent([ ...yValues, gridMin, gridMax ])
+        const xExtent = array.extent([ ...xValues ])
+
+        const {
+            yMin = yExtent[ 0 ],
+            yMax = yExtent[ 1 ],
+            xMin = xExtent[ 0 ],
+            xMax = xExtent[ 1 ],
+        } = this.props
+
+        //invert range to support svg coordinate system
+        const y = yScale()
+            .domain([ yMin, yMax ])
+            .range([ height - bottom, top ])
+            .clamp(clampY)
+
+        const x = xScale()
+            .domain([ xMin, xMax ])
+            .range([ left, width - right ])
+            .clamp(clampX)
+
+        const paths = this.createPaths({
+            data: mappedData,
+            x,
+            y,
+        })
+
+        const ticks = y.ticks(numberOfTicks)
+
+        const extraProps = {
+            x,
+            y,
+            data,
+            ticks,
+            width,
+            height,
+            ...paths,
+        }
+
+        return (
+            <View style={ style }>
+                <View style={{ flex: 1 }} onLayout={ event => this._onLayout(event) }>
+                    {
+                        height > 0 && width > 0 &&
+                        <Svg style={{ height, width }}>
+                            {
+                                React.Children.map(children, child => {
+                                    if (child && child.props.belowChart) {
+                                        return React.cloneElement(child, extraProps)
+                                    }
+                                    return null
+                                })
+                            }
+                            <Path
+                                fill={ 'none' }
+                                { ...svg }
+                                d={ paths.path }
+                                animate={ animate }
+                                animationDuration={ animationDuration }
+                            />
+                            {
+                                React.Children.map(children, child => {
+                                    if (child && !child.props.belowChart) {
+                                        return React.cloneElement(child, extraProps)
+                                    }
+                                    return null
+                                })
+                            }
+                        </Svg>
+                    }
+                </View>
+            </View>
+        )
+    }
+}
+
+Chart.propTypes = {
+    data: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.object),
+        PropTypes.arrayOf(PropTypes.number),
+        PropTypes.arrayOf(PropTypes.array),
+    ]).isRequired,
+    svg: PropTypes.object,
+
+    style: PropTypes.any,
+
+    animate: PropTypes.bool,
+    animationDuration: PropTypes.number,
+
+    curve: PropTypes.func,
+    contentInset: PropTypes.shape({
+        top: PropTypes.number,
+        left: PropTypes.number,
+        right: PropTypes.number,
+        bottom: PropTypes.number,
+    }),
+    numberOfTicks: PropTypes.number,
+
+    gridMin: PropTypes.number,
+    gridMax: PropTypes.number,
+
+    yMin: PropTypes.any,
+    yMax: PropTypes.any,
+    xMin: PropTypes.any,
+    xMax: PropTypes.any,
+    clampX: PropTypes.bool,
+    clampY: PropTypes.bool,
+
+    xScale: PropTypes.func,
+    yScale: PropTypes.func,
+
+    xAccessor: PropTypes.func,
+    yAccessor: PropTypes.func,
+}
+
+Chart.defaultProps = {
+    svg: {},
+    width: 100,
+    height: 100,
+    curve: shape.curveLinear,
+    contentInset: {},
+    numberOfTicks: 10,
+    xScale: scale.scaleLinear,
+    yScale: scale.scaleLinear,
+    xAccessor: ({ index }) => index,
+    yAccessor: ({ item }) => item,
+}
+
+export default Chart

--- a/src/line-chart/index.js
+++ b/src/line-chart/index.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import LineChart from './line-chart'
+import LineChartGrouped from './line-chart-grouped'
+
+const LineChartGate = (props) => {
+    const { data } = props
+
+    if (data[0].hasOwnProperty('data')) {
+        return <LineChartGrouped { ...props } />
+    }
+
+    return <LineChart { ...props } />
+}
+
+export default LineChartGate

--- a/src/line-chart/line-chart-grouped.js
+++ b/src/line-chart/line-chart-grouped.js
@@ -1,0 +1,31 @@
+import * as shape from 'd3-shape'
+import ChartGrouped from '../chart/chart-grouped'
+
+class LineChartGrouped extends ChartGrouped {
+
+    createPaths({ data, x, y }) {
+        const { curve } = this.props
+
+        const lines = data.map((line) => shape.line()
+            .x((d) => x(d.x))
+            .y(d => y(d.y))
+            .defined(item => typeof item.y === 'number')
+            .curve(curve)
+            (line))
+
+        return {
+            path: lines,
+            lines,
+        }
+    }
+}
+
+LineChartGrouped.propTypes = {
+    ...ChartGrouped.propTypes,
+}
+
+LineChartGrouped.defaultProps = {
+    ...ChartGrouped.defaultProps,
+}
+
+export default LineChartGrouped

--- a/src/line-chart/line-chart.js
+++ b/src/line-chart/line-chart.js
@@ -1,5 +1,5 @@
 import * as shape from 'd3-shape'
-import Chart from './chart'
+import Chart from '../chart/chart'
 
 class LineChart extends Chart {
 

--- a/src/stacked-bar-chart/index.js
+++ b/src/stacked-bar-chart/index.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import StackedBarChart from './stacked-bar-chart'
+import StackedBarChartGrouped from './stacked-bar-grouped'
+
+const StackedBarChartGate = props => {
+    const { data } = props
+
+    if (data[0].hasOwnProperty('data')) {
+        return <StackedBarChartGrouped { ...props } />
+    }
+
+    return <StackedBarChart { ...props } />
+}
+
+export default StackedBarChartGate

--- a/src/stacked-bar-chart/stacked-bar-grouped.js
+++ b/src/stacked-bar-chart/stacked-bar-grouped.js
@@ -1,0 +1,281 @@
+import React, { PureComponent } from 'react'
+import { View } from 'react-native'
+import PropTypes from 'prop-types'
+import Svg from 'react-native-svg'
+import * as array from 'd3-array'
+import * as scale from 'd3-scale'
+import * as shape from 'd3-shape'
+import Path from '../animated-path'
+
+class StackedBarGrouped extends PureComponent {
+    state = {
+        width: 0,
+        height: 0,
+    }
+
+    _onLayout(event) {
+        const { nativeEvent: { layout: { height, width } } } = event
+        this.setState({ height, width })
+    }
+
+    calcXScale(domain) {
+        const { horizontal, contentInset: { left = 0, right = 0 }, spacingInner, spacingOuter } = this.props
+
+        const { width } = this.state
+
+        if (horizontal) {
+            return scale
+                .scaleLinear()
+                .domain(domain)
+                .range([ left, width - right ])
+        }
+
+        return scale
+            .scaleBand()
+            .domain(domain)
+            .range([ left, width - right ])
+            .paddingInner([ spacingInner ])
+            .paddingOuter([ spacingOuter ])
+    }
+
+    calcYScale(domain) {
+        const { horizontal, contentInset: { top = 0, bottom = 0 }, spacingInner, spacingOuter } = this.props
+
+        const { height } = this.state
+
+        if (horizontal) {
+            return scale
+                .scaleBand()
+                .domain(domain)
+                .range([ top, height - bottom ])
+                .paddingInner([ spacingInner ])
+                .paddingOuter([ spacingOuter ])
+        }
+
+        return scale
+            .scaleLinear()
+            .domain(domain)
+            .range([ height - bottom, top ])
+    }
+
+    calcAreas(x, y, series) {
+        const { horizontal, colors, keys, data } = this.props
+        let areas
+        let barWidth
+
+        if (horizontal) {
+            barWidth = y.bandwidth() / data.length
+
+            areas = series.map((stack, stackIndex) => {
+                return stack.map((serie, keyIndex) => {
+                    return serie.map((entry, entryIndex) => {
+                        const path = shape
+                            .area()
+                            .x0(d => x(d[0]))
+                            .x1(d => x(d[1]))
+                            .y((d, _index) => (_index === 0 ?
+                                y(entryIndex) + (barWidth * stackIndex) :
+                                y(entryIndex) + barWidth + (barWidth * stackIndex)))
+                            .defined(d => !isNaN(d[0]) && !isNaN(d[1]))([ entry, entry ])
+
+                        return {
+                            path,
+                            color: colors[stackIndex][keyIndex],
+                            key: keys[stackIndex][keyIndex],
+                        }
+                    })
+                })
+            })
+        } else {
+            barWidth = x.bandwidth() / data.length
+
+            areas = series.map((stack, stackIndex) => {
+                return stack.map((serie, keyIndex) => {
+                    return serie.map((entry, entryIndex) => {
+                        const path = shape
+                            .area()
+                            .y0(d => y(d[0]))
+                            .y1(d => y(d[1]))
+                            .x((d, _index) => (_index === 0 ?
+                                x(entryIndex) + (barWidth * stackIndex) :
+                                x(entryIndex) + barWidth + (barWidth * stackIndex))
+                            )
+                            .defined(d => !isNaN(d[0]) && !isNaN(d[1]))([ entry, entry ])
+
+                        return {
+                            path,
+                            color: colors[stackIndex][keyIndex],
+                            key: keys[stackIndex][keyIndex],
+                        }
+                    })
+                })
+            })
+        }
+
+        return array.merge(areas)
+    }
+
+    calcExtent(values) {
+        const {
+            gridMax,
+            gridMin,
+        } = this.props
+
+        // One more merge for stacked groups
+        const mergedValues = array.merge(values)
+
+        return array.extent([ ...mergedValues, gridMin, gridMax ])
+    }
+
+    calcIndexes() {
+        const { data } = this.props
+
+        // Must return an array with indexes for the number of groups to be shown
+        return data[0].data.map((_, index) => index)
+    }
+
+    getSeries() {
+        const { data, keys, offset, order, valueAccessor } = this.props
+
+        return data.map((obj, index) => shape
+            .stack()
+            .keys(keys[index])
+            .value((item, key) => valueAccessor({ item, key }))
+            .order(order)
+            .offset(offset)(obj.data))
+    }
+
+    render() {
+        const {
+            data,
+            animate,
+            animationDuration,
+            style,
+            numberOfTicks,
+            children,
+            horizontal,
+        } = this.props
+
+        const { height, width } = this.state
+
+        if (data.length === 0) {
+            return <View style={ style } />
+        }
+
+        const series = this.getSeries()
+
+        //double merge arrays to extract just the values
+        const values = array.merge(array.merge(series))
+        const indexes = this.calcIndexes(values)
+
+        const extent = this.calcExtent(values)
+        const ticks = array.ticks(extent[0], extent[1], numberOfTicks)
+
+        const xDomain = horizontal ? extent : indexes
+        const yDomain = horizontal ? indexes : extent
+
+        const x = this.calcXScale(xDomain)
+        const y = this.calcYScale(yDomain)
+
+        const stacks = this.calcAreas(x, y, series)
+
+        const extraProps = {
+            x,
+            y,
+            width,
+            height,
+            ticks,
+            data,
+        }
+
+        return (
+            <View style={ style }>
+                <View style={{ flex: 1 }} onLayout={ event => this._onLayout(event) }>
+                    {
+                        height > 0 && width > 0 &&
+                        <Svg style={{ height, width }}>
+                            {
+                                React.Children.map(children, child => {
+                                    if (child && child.props.belowChart) {
+                                        return React.cloneElement(child, extraProps)
+                                    }
+                                    return null
+                                })
+                            }
+                            {
+                                stacks.map((areas, indexStack) => {
+                                    const areaIndex = indexStack % data.length
+
+                                    return areas.map((bar, indexArea) => {
+                                        const keyIndex = indexArea % data[areaIndex].data.length
+                                        const key = `${areaIndex}-${keyIndex}-${bar.key}`
+
+                                        const { svg } = data[areaIndex].data[keyIndex][bar.key]
+
+                                        return (
+                                            <Path
+                                                key={ key }
+                                                fill={ bar.color }
+                                                { ...svg }
+                                                d={ bar.path }
+                                                animate={ animate }
+                                                animationDuration={ animationDuration }
+                                            />
+                                        )
+                                    })
+                                })
+
+                            }
+                            {
+                                React.Children.map(children, child => {
+                                    if (child && !child.props.belowChart) {
+                                        return React.cloneElement(child, extraProps)
+                                    }
+                                    return null
+                                })
+                            }
+                        </Svg>
+                    }
+                </View>
+            </View>
+        )
+    }
+}
+
+StackedBarGrouped.propTypes = {
+    data: PropTypes.arrayOf(PropTypes.object),
+    keys: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired,
+    colors: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired,
+    offset: PropTypes.func,
+    order: PropTypes.func,
+    style: PropTypes.any,
+    spacingInner: PropTypes.number,
+    spacingOuter: PropTypes.number,
+    animate: PropTypes.bool,
+    animationDuration: PropTypes.number,
+    contentInset: PropTypes.shape({
+        top: PropTypes.number,
+        left: PropTypes.number,
+        right: PropTypes.number,
+        bottom: PropTypes.number,
+    }),
+    gridMin: PropTypes.number,
+    gridMax: PropTypes.number,
+    valueAccessor: PropTypes.func,
+}
+
+StackedBarGrouped.defaultProps = {
+    spacingInner: 0.05,
+    spacingOuter: 0.05,
+    offset: shape.stackOffsetNone,
+    order: shape.stackOrderNone,
+    width: 100,
+    height: 100,
+    showZeroAxis: true,
+    contentInset: {},
+    numberOfTicks: 10,
+    showGrid: true,
+    valueAccessor: ({ item, key }) => item[key],
+}
+
+export default StackedBarGrouped

--- a/storybook/stories/bar-stack/grouped.js
+++ b/storybook/stories/bar-stack/grouped.js
@@ -1,0 +1,132 @@
+import React from 'react'
+import { StackedBarChart, Grid } from 'react-native-svg-charts'
+
+class StackedBarChartExample extends React.PureComponent {
+    render() {
+        const data = [
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 400,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 600,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 400,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 400,
+                        oranges: 200,
+                    }],
+            },
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 400,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 600,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 400,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 400,
+                        oranges: 200,
+                    }],
+            },
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 400,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 400,
+                        oranges: 600,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 400,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 400,
+                        oranges: 2500,
+                    }],
+            },
+        ]
+
+        const colors = [[ '#8800cc', '#aa00ff' ], [ '#dd99ff', '#cc66ff' ], [ '#eeccff' ]]
+        const keys = [[ 'apples', 'bananas' ], [ 'cherries', 'dates' ], [ 'oranges' ]]
+
+        return (
+            <StackedBarChart
+                style={{ height: 200 }}
+                keys={ keys }
+                colors={ colors }
+                data={ data }
+                showGrid={ false }
+                contentInset={{ top: 30, bottom: 30 }}
+            >
+                <Grid />
+            </StackedBarChart >
+        )
+    }
+}
+
+export default StackedBarChartExample

--- a/storybook/stories/bar-stack/horizontal-grouped.js
+++ b/storybook/stories/bar-stack/horizontal-grouped.js
@@ -1,0 +1,133 @@
+import React from 'react'
+import { StackedBarChart, Grid } from 'react-native-svg-charts'
+
+class StackedBarChartExample extends React.PureComponent {
+    render() {
+        const data = [
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 1240,
+                        oranges: 4780,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 3240,
+                        oranges: 3300,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 1900,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 650,
+                        oranges: 2000,
+                    }],
+            },
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 1240,
+                        oranges: 4780,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 3240,
+                        oranges: 3300,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 1900,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 650,
+                        oranges: 2000,
+                    }],
+            },
+            {
+                data: [
+                    {
+                        month: new Date(2015, 0, 1),
+                        apples: 3840,
+                        bananas: 1920,
+                        cherries: 960,
+                        dates: 1240,
+                        oranges: 4780,
+                    },
+                    {
+                        month: new Date(2015, 1, 1),
+                        apples: 1600,
+                        bananas: 1440,
+                        cherries: 960,
+                        dates: 3240,
+                        oranges: 3300,
+                    },
+                    {
+                        month: new Date(2015, 2, 1),
+                        apples: 640,
+                        bananas: 960,
+                        cherries: 3640,
+                        dates: 1900,
+                        oranges: 800,
+                    },
+                    {
+                        month: new Date(2015, 3, 1),
+                        apples: 3320,
+                        bananas: 480,
+                        cherries: 640,
+                        dates: 650,
+                        oranges: 2000,
+                    }],
+            },
+        ]
+
+        const colors = [[ '#8800cc', '#aa00ff', '#dd99ff' ], [ '#cc66ff' ], [ '#eeccff' ]]
+        const keys = [[ 'apples', 'cherries', 'bananas' ], [ 'dates' ], [ 'oranges' ]]
+
+        return (
+            <StackedBarChart
+                style={{ height: 200 }}
+                keys={ keys }
+                colors={ colors }
+                data={ data }
+                showGrid={ false }
+                contentInset={{ top: 30, bottom: 30 }}
+                horizontal
+            >
+                <Grid direction={ Grid.Direction.VERTICAL } />
+            </StackedBarChart >
+        )
+    }
+}
+
+export default StackedBarChartExample

--- a/storybook/stories/bar-stack/index.js
+++ b/storybook/stories/bar-stack/index.js
@@ -4,10 +4,14 @@ import { storiesOf } from '@storybook/react-native'
 import Standard from './standard'
 import Horizontal from './horizontal'
 import WithOnPress from './with-on-press'
+import Grouped from './grouped'
+import HorizontalGrouped from './horizontal-grouped'
 import ShowcaseCard from '../showcase-card'
 
 storiesOf('BarStack', module)
-    .addDecorator(getStory => <ShowcaseCard>{ getStory() }</ShowcaseCard>)
-    .add('Standard', () => <Standard/>)
-    .add('Horizontal', () => <Horizontal/>)
-    .add('With onPress', () => <WithOnPress/>)
+    .addDecorator(getStory => <ShowcaseCard>{getStory()}</ShowcaseCard>)
+    .add('Standard', () => <Standard />)
+    .add('Horizontal', () => <Horizontal />)
+    .add('With onPress', () => <WithOnPress />)
+    .add('Grouped', () => <Grouped />)
+    .add('Horizontal - grouped', () => <HorizontalGrouped />)

--- a/storybook/stories/line-chart/grouped.js
+++ b/storybook/stories/line-chart/grouped.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { LineChart, Grid } from 'react-native-svg-charts'
+
+class GroupedLineChartExample extends React.PureComponent {
+
+    render() {
+
+        const data1 = [ 50, 10, 40, 95, -4, -24, 85, 91, 35, 53, -53, 24, 50, -20, -80 ]
+        const data2 = [ -87, 66, -69, 92, -40, -61, 16, 62, 20, -93, -54, 47, -89, -44, 18 ]
+
+        const data = [
+            {
+                data: data1,
+                svg: { stroke: '#8800cc' },
+            },
+            {
+                data: data2,
+                svg: { stroke: 'green' },
+            },
+        ]
+
+        return (
+            <LineChart
+                style={{ height: 200 }}
+                data={ data }
+                contentInset={{ top: 20, bottom: 20 }}
+            >
+                <Grid />
+            </LineChart>
+        )
+    }
+
+}
+
+export default GroupedLineChartExample

--- a/storybook/stories/line-chart/index.js
+++ b/storybook/stories/line-chart/index.js
@@ -4,10 +4,12 @@ import { storiesOf } from '@storybook/react-native'
 import Standard from './standard'
 import Partial from './partial'
 import WithGradient from './with-gradient'
+import Grouped from './grouped'
 import ShowcaseCard from '../showcase-card'
 
 storiesOf('LineChart')
-    .addDecorator(getStory => <ShowcaseCard>{ getStory() }</ShowcaseCard>)
-    .add('Standard', () => <Standard/>)
-    .add('Partial', () => <Partial/>)
-    .add('With gradient', () => <WithGradient/>)
+    .addDecorator(getStory => <ShowcaseCard>{getStory()}</ShowcaseCard>)
+    .add('Standard', () => <Standard />)
+    .add('Partial', () => <Partial />)
+    .add('With gradient', () => <WithGradient />)
+    .add('Grouped', () => <Grouped />)


### PR DESCRIPTION
Adds the ability to group line charts together addressing #205.  This uses the same data structure as grouping bar charts:

```javascript
data: [
  { data: [], svg: {} },
  ...
]
```

I've confirmed that all lines display correctly and that all children can receive touch events.