### PR TITLE
Fix for PieChart onPress

### DIFF
--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -128,7 +128,7 @@ class PieChart extends PureComponent {
                 >
                     {
                         height > 0 && width > 0 &&
-                        <Svg style={{ height, width }}>
+                        <Svg style={{ height, width }} viewBox={`0 0 ${width} ${height}`}>
                             {/* center the progress circle*/}
                             <G
                                 x={ width / 2 }


### PR DESCRIPTION
Hi @JesperLekland,

I've had a problem for the past couple of days where the PieChart wasn't handling the onPress event correctly.  It almost seemed like it hadn't shifted the hit area down the y axis as I could press above the area it should be.  

After much trial and error, setting the viewBox seems to solve this (not exactly sure why as stepping through react-native-svg seems to hitTest fine without it).

Any way, hopefully this will solve someone else's agro if they are trying to get it to work.

Cheers,
Chris