### PR TITLE
Fix 'transparent' color for X-Axis and Y-Axis in RN 0.57

### DIFF
--- a/src/x-axis.js
+++ b/src/x-axis.js
@@ -87,7 +87,7 @@ class XAxis extends PureComponent {
                     onLayout={ event => this._onLayout(event) }
                 >
                     {/*invisible text to allow for parent resizing*/}
-                    <Text style={{ color: 'transparent', fontSize: svg.fontSize }}>
+                    <Text style={{ opacity: 0, fontSize: svg.fontSize }}>
                         { formatLabel(ticks[0], 0) }
                     </Text>
                     {

--- a/src/y-axis.js
+++ b/src/y-axis.js
@@ -100,7 +100,7 @@ class YAxis extends PureComponent {
                 >
                     {/*invisible text to allow for parent resizing*/}
                     <Text
-                        style={{ color: 'transparent', fontSize: svg.fontSize }}
+                        style={{ opacity: 0, fontSize: svg.fontSize }}
                     >
                         {longestValue}
                     </Text>


### PR DESCRIPTION
It looks like now in RN 0.57 there is a bug that `transparent` doesn't work properly with `View` component without `backgroundColor` specified.

<img width="237" alt="screen shot 2018-11-02 at 20 41 40" src="https://user-images.githubusercontent.com/2836281/47937009-c50f7d00-dedf-11e8-9fbf-e7d71809e61e.png">
