### PR TITLE
Text with transparent color is rendered as visible color.

### DIFF
--- a/src/x-axis.js
+++ b/src/x-axis.js
@@ -87,7 +87,7 @@ class XAxis extends PureComponent {
                     onLayout={ event => this._onLayout(event) }
                 >
                     {/*invisible text to allow for parent resizing*/}
-                    <Text style={{ color: 'transparent', fontSize: svg.fontSize }}>
+                    <Text style={{ color: 'transparent', opacity: 0, fontSize: svg.fontSize }}>
                         { formatLabel(ticks[0], 0) }
                     </Text>
                     {

--- a/src/y-axis.js
+++ b/src/y-axis.js
@@ -100,7 +100,7 @@ class YAxis extends PureComponent {
                 >
                     {/*invisible text to allow for parent resizing*/}
                     <Text
-                        style={{ color: 'transparent', fontSize: svg.fontSize }}
+                        style={{ color: 'transparent', opacity: 0, fontSize: svg.fontSize }}
                     >
                         {longestValue}
                     </Text>


### PR DESCRIPTION
After upgrade to RN 0.57.4 the component in `xAxis` and `yAxis` was not rendered properly. Instead of transparent color, it render with default color. It could be related to RN changes itself but haven't checked it to be honest.

```js
{/*invisible text to allow for parent resizing*/}
<Text
   style={{ color: 'transparent', fontSize: svg.fontSize }}
>
  {longestValue}
</Text>
```

adding opacity fixed the problem.