### PR TITLE
Feature/multiline x axis

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,6 +713,7 @@ class XAxisExample extends React.PureComponent {
 | svg | `{}` | Default svg props **for all labels**. Supports all svg props an svg text normally supports. This styles will be overriden if there are specific styles for a given data object  |
 | formatLabel | `value => value` | A utility function to format the text before it is displayed, e.g `value => "day" + value`. Passes back the value provided by the `xAccessor` |
 | contentInset | { left: 0, right: 0 } | Used to sync layout with chart (if same prop used there) |
+| splitOnLineBreaks | false | Forces line breaks on formatted axis labels. |
 
 #### Arguments to children
 

--- a/src/x-axis.js
+++ b/src/x-axis.js
@@ -3,17 +3,20 @@ import PropTypes from 'prop-types'
 import { Text, View } from 'react-native'
 import * as d3Scale from 'd3-scale'
 import * as array from 'd3-array'
-import Svg, { Text as SVGText } from 'react-native-svg'
+import Svg, { Text as SVGText, TSpan } from 'react-native-svg'
 
 class XAxis extends PureComponent {
-
     state = {
         width: 0,
         height: 0,
-    }
+    };
 
     _onLayout(event) {
-        const { nativeEvent: { layout: { width, height } } } = event
+        const {
+            nativeEvent: {
+                layout: { width, height },
+            },
+        } = event
 
         if (width !== this.state.width) {
             this.setState({ width, height })
@@ -25,10 +28,7 @@ class XAxis extends PureComponent {
             scale,
             spacingInner,
             spacingOuter,
-            contentInset: {
-                left  = 0,
-                right = 0,
-            },
+            contentInset: { left = 0, right = 0 },
         } = this.props
 
         const { width } = this.state
@@ -38,20 +38,35 @@ class XAxis extends PureComponent {
             .range([ left, width - right ])
 
         if (scale === d3Scale.scaleBand) {
-
-            x
-                .paddingInner([ spacingInner ])
-                .paddingOuter([ spacingOuter ])
+            x.paddingInner([ spacingInner ]).paddingOuter([ spacingOuter ])
 
             //add half a bar to center label
-            return (value) => x(value) + (x.bandwidth() / 2)
+            return value => x(value) + x.bandwidth() / 2
         }
 
         return x
     }
 
-    render() {
+    _getTick({ value, x, index }) {
+        const { splitOnLineBreaks, formatLabel, svg } = this.props
+        const formattedValue = formatLabel(value, index)
 
+        if (splitOnLineBreaks) {
+            return formattedValue.split('\n').map((line, lineIndex) => (
+                <TSpan
+                    key={ line }
+                    textAnchor="middle"
+                    x={ x(value) }
+                    dy={ lineIndex ? svg.fontSize * 1.2 : 0 }>
+                    {line.trim()}
+                </TSpan>
+            ))
+        }
+
+        return formattedValue
+    }
+
+    render() {
         const {
             style,
             scale,
@@ -68,62 +83,58 @@ class XAxis extends PureComponent {
         const { height, width } = this.state
 
         if (data.length === 0) {
-            return <View style={ style }/>
+            return <View style={ style } />
         }
 
         const values = data.map((item, index) => xAccessor({ item, index }))
-        const extent  = array.extent(values)
-        const domain = scale === d3Scale.scaleBand ?
-            values :
-            [ min || extent[ 0 ], max || extent[ 1 ] ]
+        const extent = array.extent(values)
+        const domain =
+            scale === d3Scale.scaleBand
+                ? values
+                : [ min || extent[0], max || extent[1] ]
 
-        const x     = this._getX(domain)
+        const x = this._getX(domain)
         const ticks = numberOfTicks ? x.ticks(numberOfTicks) : values
 
         return (
             <View style={ style }>
-                <View
-                    style={{ flexGrow: 1 }}
-                    onLayout={ event => this._onLayout(event) }
-                >
+                <View style={{ flexGrow: 1 }} onLayout={ event => this._onLayout(event) }>
                     {/*invisible text to allow for parent resizing*/}
                     <Text style={{ color: 'transparent', fontSize: svg.fontSize }}>
-                        { formatLabel(ticks[0], 0) }
+                        {formatLabel(ticks[0], 0)}
                     </Text>
-                    {
-                        height > 0 && width > 0 &&
-                        <Svg style={{
-                            position: 'absolute',
-                            top: 0,
-                            left: 0,
-                            height,
-                            width,
-                        }}>
+                    {height > 0 &&
+                        width > 0 && (
+                        <Svg
+                            style={{
+                                position: 'absolute',
+                                top: 0,
+                                left: 0,
+                                height,
+                                width,
+                            }}>
                             {children}
-                            {
-                                // don't render labels if width isn't measured yet,
+                            {// don't render labels if width isn't measured yet,
                                 // causes rendering issues
                                 width > 0 &&
-                                ticks.map((value, index) => {
-                                    const { svg: valueSvg = {} } = data[ index ] || {}
+                                    ticks.map((value, index) => {
+                                        const { svg: valueSvg = {} } = data[index] || {}
 
-                                    return (
-                                        <SVGText
-                                            textAnchor={ 'middle' }
-                                            originX={ x(value) }
-                                            alignmentBaseline={ 'hanging' }
-                                            { ...svg }
-                                            { ...valueSvg }
-                                            key={ index }
-                                            x={ x(value) }
-                                        >
-                                            {formatLabel(value, index)}
-                                        </SVGText>
-                                    )
-                                })
-                            }
+                                        return (
+                                            <SVGText
+                                                textAnchor={ 'middle' }
+                                                originX={ x(value) }
+                                                alignmentBaseline={ 'hanging' }
+                                                { ...svg }
+                                                { ...valueSvg }
+                                                key={ index }
+                                                x={ x(value) }>
+                                                {this._getTick({ value, x, index })}
+                                            </SVGText>
+                                        )
+                                    })}
                         </Svg>
-                    }
+                    )}
                 </View>
             </View>
         )
@@ -131,10 +142,9 @@ class XAxis extends PureComponent {
 }
 
 XAxis.propTypes = {
-    data: PropTypes.arrayOf(PropTypes.oneOfType([
-        PropTypes.number,
-        PropTypes.object,
-    ])).isRequired,
+    data: PropTypes.arrayOf(
+        PropTypes.oneOfType([ PropTypes.number, PropTypes.object ]),
+    ).isRequired,
     spacingInner: PropTypes.number,
     spacingOuter: PropTypes.number,
     formatLabel: PropTypes.func,
@@ -142,12 +152,17 @@ XAxis.propTypes = {
         left: PropTypes.number,
         right: PropTypes.number,
     }),
-    scale: PropTypes.oneOf([ d3Scale.scaleTime, d3Scale.scaleLinear, d3Scale.scaleBand ]),
+    scale: PropTypes.oneOf([
+        d3Scale.scaleTime,
+        d3Scale.scaleLinear,
+        d3Scale.scaleBand,
+    ]),
     numberOfTicks: PropTypes.number,
     xAccessor: PropTypes.func,
     svg: PropTypes.object,
     min: PropTypes.any,
     max: PropTypes.any,
+    splitOnLineBreaks: PropTypes.bool,
 }
 
 XAxis.defaultProps = {
@@ -158,6 +173,7 @@ XAxis.defaultProps = {
     xAccessor: ({ index }) => index,
     scale: d3Scale.scaleLinear,
     formatLabel: value => value,
+    splitOnLineBreaks: false,
 }
 
 export default XAxis

--- a/src/x-axis.js
+++ b/src/x-axis.js
@@ -58,7 +58,7 @@ class XAxis extends PureComponent {
                     textAnchor="middle"
                     x={ x(value) }
                     dy={ lineIndex ? svg.fontSize * 1.2 : 0 }>
-                    {line.trim()}
+                    {line}
                 </TSpan>
             ))
         }


### PR DESCRIPTION
Adds the ability to set the `splitOnLineBreaks` prop to the XAxis to enable multiline ticks.  If the user sets the property, the label will be formatted the same, but line breaks will be forced where '\n' characters appear with a dy of 1.2 times font size.

<img width="331" alt="screen shot 2018-11-16 at 5 02 33 pm" src="https://user-images.githubusercontent.com/22638838/48649691-71ae2c00-e9c1-11e8-892c-0483540765ef.png">

Also seems like there was a lot of auto formatting based on the project rules.