### PR TITLE
Fixed Android label issue

### DIFF
--- a/src/x-axis.js
+++ b/src/x-axis.js
@@ -26,7 +26,7 @@ class XAxis extends PureComponent {
             spacingInner,
             spacingOuter,
             contentInset: {
-                left  = 0,
+                left = 0,
                 right = 0,
             },
         } = this.props
@@ -68,62 +68,73 @@ class XAxis extends PureComponent {
         const { height, width } = this.state
 
         if (data.length === 0) {
-            return <View style={ style }/>
+            return <View style={ style } />
         }
 
         const values = data.map((item, index) => xAccessor({ item, index }))
-        const extent  = array.extent(values)
+        const extent = array.extent(values)
         const domain = scale === d3Scale.scaleBand ?
             values :
-            [ min || extent[ 0 ], max || extent[ 1 ] ]
+            [ min || extent[0], max || extent[1] ]
 
-        const x     = this._getX(domain)
+        const x = this._getX(domain)
         const ticks = numberOfTicks ? x.ticks(numberOfTicks) : values
 
         return (
             <View style={ style }>
                 <View
-                    style={{ flexGrow: 1 }}
-                    onLayout={ event => this._onLayout(event) }
-                >
+                    style={
+                        height && width
+                            ? {
+                                height,
+                                width,
+                            }
+                            : { flexGrow: 1 }
+                    }>
                     {/*invisible text to allow for parent resizing*/}
-                    <Text style={{ color: 'transparent', fontSize: svg.fontSize }}>
-                        { formatLabel(ticks[0], 0) }
-                    </Text>
-                    {
-                        height > 0 && width > 0 &&
-                        <Svg style={{
-                            position: 'absolute',
-                            top: 0,
-                            left: 0,
-                            height,
-                            width,
-                        }}>
+                    {!height &&
+                        !width && (
+                        <Text
+                            onLayout={ event => this._onLayout(event) }
+                            style={{ color: 'transparent', fontSize: svg.fontSize }}>
+                            {formatLabel(ticks[0], 0)}
+                        </Text>
+                    )}
+                    {height > 0 &&
+                        width > 0 && (
+                        <Svg
+                            style={{
+                                position: 'absolute',
+                                top: 0,
+                                left: 0,
+                                height,
+                                width,
+                            }}>
                             {children}
                             {
                                 // don't render labels if width isn't measured yet,
                                 // causes rendering issues
                                 width > 0 &&
-                                ticks.map((value, index) => {
-                                    const { svg: valueSvg = {} } = data[ index ] || {}
+                                    ticks.map((value, index) => {
+                                        const { svg: valueSvg = {} } = data[index] || {}
 
-                                    return (
-                                        <SVGText
-                                            textAnchor={ 'middle' }
-                                            originX={ x(value) }
-                                            alignmentBaseline={ 'hanging' }
-                                            { ...svg }
-                                            { ...valueSvg }
-                                            key={ index }
-                                            x={ x(value) }
-                                        >
-                                            {formatLabel(value, index)}
-                                        </SVGText>
-                                    )
-                                })
+                                        return (
+                                            <SVGText
+                                                textAnchor={ 'middle' }
+                                                originX={ x(value) }
+                                                alignmentBaseline={ 'hanging' }
+                                                { ...svg }
+                                                { ...valueSvg }
+                                                key={ index }
+                                                x={ x(value) }
+                                            >
+                                                {formatLabel(value, index)}
+                                            </SVGText>
+                                        )
+                                    })
                             }
                         </Svg>
-                    }
+                    )}
                 </View>
             </View>
         )

--- a/src/y-axis.js
+++ b/src/y-axis.js
@@ -6,15 +6,28 @@ import * as d3Scale from 'd3-scale'
 import * as array from 'd3-array'
 
 class YAxis extends PureComponent {
-
     state = {
         height: 0,
         width: 0,
-    }
+    };
 
     _onLayout(event) {
-        const { nativeEvent: { layout: { height, width } } } = event
-        this.setState({ height, width })
+        const {
+            nativeEvent: {
+                layout: { height },
+            },
+        } = event
+        this.setState({ height })
+    }
+
+    _onLayoutPlaceHolder(event) {
+        const {
+            nativeEvent: {
+                layout: { width },
+            },
+        } = event
+
+        this.setState({ width })
     }
 
     getY(domain) {
@@ -22,10 +35,7 @@ class YAxis extends PureComponent {
             scale,
             spacingInner,
             spacingOuter,
-            contentInset: {
-                top = 0,
-                bottom = 0,
-            },
+            contentInset: { top = 0, bottom = 0 },
         } = this.props
 
         const { height } = this.state
@@ -35,7 +45,6 @@ class YAxis extends PureComponent {
             .range([ height - bottom, top ])
 
         if (scale === d3Scale.scaleBand) {
-
             // use index as domain identifier instead of value since
             // same value can occur at several places in dataPoints
             y
@@ -45,14 +54,13 @@ class YAxis extends PureComponent {
                 .paddingOuter([ spacingOuter ])
 
             //add half a bar to center label
-            return (value) => y(value) + (y.bandwidth() / 2)
+            return value => y(value) + y.bandwidth() / 2
         }
 
         return y
     }
 
     render() {
-
         const {
             style,
             data,
@@ -67,75 +75,84 @@ class YAxis extends PureComponent {
         const { height, width } = this.state
 
         if (data.length === 0) {
-            return <View style={ style }/>
+            return <View style={ style } />
         }
 
         const values = data.map((item, index) => yAccessor({ item, index }))
 
         const extent = array.extent([ ...values, min, max ])
 
-        const {
-            min = extent[ 0 ],
-            max = extent[ 1 ],
-        } = this.props
+        const { min = extent[0], max = extent[1] } = this.props
 
         const domain = scale === d3Scale.scaleBand ? values : [ min, max ]
 
         //invert range to support svg coordinate system
         const y = this.getY(domain)
 
-        const ticks = scale === d3Scale.scaleBand ?
-            values :
-            y.ticks(numberOfTicks)
+        const ticks = scale === d3Scale.scaleBand ? values : y.ticks(numberOfTicks)
 
         const longestValue = ticks
-            .map((value, index) => formatLabel(value, index))
-            .reduce((prev, curr) => prev.toString().length > curr.toString().length ? prev : curr, 0)
+            .map((value, index) => formatLabel(value, index, ticks.length))
+            .reduce(
+                (prev, curr) =>
+                    prev.toString().length > curr.toString().length ? prev : curr,
+                0,
+            )
 
         return (
             <View style={ [ style ] }>
                 <View
-                    style={{ flexGrow: 1 }}
                     onLayout={ event => this._onLayout(event) }
-                >
+                    style={
+                        height && width
+                            ? {
+                                height,
+                                width,
+                            }
+                            : { flexGrow: 1 }
+                    }>
                     {/*invisible text to allow for parent resizing*/}
-                    <Text
-                        style={{ color: 'transparent', fontSize: svg.fontSize }}
-                    >
-                        {longestValue}
-                    </Text>
-                    {
-                        height > 0 && width > 0 &&
-                        <Svg style={{
-                            position: 'absolute',
-                            top: 0,
-                            left: 0,
-                            height,
-                            width,
-                        }}>
+                    {!width && (
+                        <Text
+                            onLayout={ event => this._onLayoutPlaceHolder(event) }
+                            style={{
+                                color: 'transparent',
+                                fontSize: svg.fontSize,
+                                paddingHorizontal: Math.floor(svg.x / 2),
+                            }}>
+                            {longestValue}
+                        </Text>
+                    )}
+                    {height > 0 &&
+                        width > 0 && (
+                        <Svg
+                            style={{
+                                position: 'absolute',
+                                top: 0,
+                                left: 0,
+                                height,
+                                width,
+                            }}>
                             {children}
-                            {
-                                // don't render labels if width isn't measured yet,
+                            {// don't render labels if width isn't measured yet,
                                 // causes rendering issues
                                 height > 0 &&
-                                ticks.map((value, index) => {
-                                    return (
-                                        <SVGText
-                                            originY={ y(value) }
-                                            textAnchor={ 'middle' }
-                                            x={ '50%' }
-                                            alignmentBaseline={ 'middle' }
-                                            { ...svg }
-                                            key={ index }
-                                            y={ y(value) }
-                                        >
-                                            {formatLabel(value, index)}
-                                        </SVGText>
-                                    )
-                                })
-                            }
+                                    ticks.map((value, index) => {
+                                        return (
+                                            <SVGText
+                                                originY={ y(value) }
+                                                textAnchor={ 'middle' }
+                                                x={ '50%' }
+                                                alignmentBaseline={ 'middle' }
+                                                { ...svg }
+                                                key={ y(value) }
+                                                y={ y(value) }>
+                                                {formatLabel(value, index, ticks.length)}
+                                            </SVGText>
+                                        )
+                                    })}
                         </Svg>
-                    }
+                    )}
                 </View>
             </View>
         )


### PR DESCRIPTION
The measurement text intended to be transparent was still showing on Android. Apparently Android doesn't like transparent text color. This fixes #248.

This also seemed to fix a lot of formatting.