### PR TITLE
Added extra props to axis children

### DIFF
--- a/src/x-axis.js
+++ b/src/x-axis.js
@@ -26,7 +26,7 @@ class XAxis extends PureComponent {
             spacingInner,
             spacingOuter,
             contentInset: {
-                left  = 0,
+                left = 0,
                 right = 0,
             },
         } = this.props
@@ -68,17 +68,24 @@ class XAxis extends PureComponent {
         const { height, width } = this.state
 
         if (data.length === 0) {
-            return <View style={ style }/>
+            return <View style={ style } />
         }
 
         const values = data.map((item, index) => xAccessor({ item, index }))
-        const extent  = array.extent(values)
+        const extent = array.extent(values)
         const domain = scale === d3Scale.scaleBand ?
             values :
-            [ min || extent[ 0 ], max || extent[ 1 ] ]
+            [ min || extent[0], max || extent[1] ]
 
-        const x     = this._getX(domain)
+        const x = this._getX(domain)
         const ticks = numberOfTicks ? x.ticks(numberOfTicks) : values
+
+        const extraProps = {
+            x,
+            ticks,
+            height,
+            formatLabel,
+        }
 
         return (
             <View style={ style }>
@@ -88,7 +95,7 @@ class XAxis extends PureComponent {
                 >
                     {/*invisible text to allow for parent resizing*/}
                     <Text style={{ opacity: 0, fontSize: svg.fontSize }}>
-                        { formatLabel(ticks[0], 0) }
+                        {formatLabel(ticks[0], 0)}
                     </Text>
                     {
                         height > 0 && width > 0 &&
@@ -100,13 +107,15 @@ class XAxis extends PureComponent {
                             width,
                         }}>
                             <G>
-                                {children}
+                                {React.Children.map(children, child => {
+                                    return React.cloneElement(child, extraProps)
+                                })}
                                 {
                                     // don't render labels if width isn't measured yet,
                                     // causes rendering issues
                                     width > 0 &&
                                     ticks.map((value, index) => {
-                                        const { svg: valueSvg = {} } = data[ index ] || {}
+                                        const { svg: valueSvg = {} } = data[index] || {}
 
                                         return (
                                             <SVGText

--- a/src/y-axis.js
+++ b/src/y-axis.js
@@ -67,7 +67,7 @@ class YAxis extends PureComponent {
         const { height, width } = this.state
 
         if (data.length === 0) {
-            return <View style={ style }/>
+            return <View style={ style } />
         }
 
         const values = data.map((item, index) => yAccessor({ item, index }))
@@ -75,8 +75,8 @@ class YAxis extends PureComponent {
         const extent = array.extent([ ...values, min, max ])
 
         const {
-            min = extent[ 0 ],
-            max = extent[ 1 ],
+            min = extent[0],
+            max = extent[1],
         } = this.props
 
         const domain = scale === d3Scale.scaleBand ? values : [ min, max ]
@@ -91,6 +91,13 @@ class YAxis extends PureComponent {
         const longestValue = ticks
             .map((value, index) => formatLabel(value, index))
             .reduce((prev, curr) => prev.toString().length > curr.toString().length ? prev : curr, 0)
+
+        const extraProps = {
+            y,
+            ticks,
+            width,
+            formatLabel,
+        }
 
         return (
             <View style={ [ style ] }>
@@ -114,7 +121,9 @@ class YAxis extends PureComponent {
                             width,
                         }}>
                             <G>
-                                {children}
+                                {React.Children.map(children, child => {
+                                    return React.cloneElement(child, extraProps)
+                                })}
                                 {
                                     // don't render labels if width isn't measured yet,
                                     // causes rendering issues


### PR DESCRIPTION
Following the example from the charts, this adds extra props fro use in laying out axes children to both the x and y axes.  Addresses #275 

This still includes a heavy formatting diff.  Please see my comment on #245 .  If need be I will remove them but I believe these are based on the in place eslint rules for the project. 