### PR TITLE
Fix blinking animation

### DIFF
--- a/src/animated-path.js
+++ b/src/animated-path.js
@@ -85,6 +85,7 @@ class AnimatedPath extends Component {
             <Path
                 ref={ ref => this.component = ref }
                 { ...this.props }
+                d={this.state.d}
             />
         )
     }

--- a/src/animated-path.js
+++ b/src/animated-path.js
@@ -85,7 +85,7 @@ class AnimatedPath extends Component {
             <Path
                 ref={ ref => this.component = ref }
                 { ...this.props }
-                d={this.state.d}
+                d={this.props.animate ? this.state.d : this.props.d}
             />
         )
     }


### PR DESCRIPTION
This PR fixes an issue with `LineChart`, `BarChart`, `StackedAreaChart` where the path briefly flickers to the new value before being animated. e.g. see this ticket. https://github.com/JesperLekland/react-native-svg-charts/issues/277 

ios before fix: https://youtu.be/jdQUTYHdJu4
android before fix: https://youtu.be/D3sh7MKdiJs

ios after fix: https://youtu.be/OPgdGwNKNRA
android after fix: https://youtu.be/WsuHOtuRvtI