### PR TITLE
Don’t render empty labels on axis

### DIFF
--- a/src/x-axis.js
+++ b/src/x-axis.js
@@ -116,7 +116,13 @@ class XAxis extends PureComponent {
                                     width > 0 &&
                                     ticks.map((value, index) => {
                                         const { svg: valueSvg = {} } = data[index] || {}
+                                        const label = formatLabel(value, index)
 
+                                        // don't render empty labels
+                                        if(!label || label === '') {
+                                            return null
+                                        }
+                                        
                                         return (
                                             <SVGText
                                                 textAnchor={ 'middle' }
@@ -127,7 +133,7 @@ class XAxis extends PureComponent {
                                                 key={ index }
                                                 x={ x(value) }
                                             >
-                                                {formatLabel(value, index)}
+                                                {label}
                                             </SVGText>
                                         )
                                     })

--- a/src/y-axis.js
+++ b/src/y-axis.js
@@ -129,6 +129,13 @@ class YAxis extends PureComponent {
                                     // causes rendering issues
                                     height > 0 &&
                                     ticks.map((value, index) => {
+                                        const label = formatLabel(value, index, ticks.length)
+                                        
+                                        // don't render empty labels
+                                        if(!label || label === '') {
+                                            return null
+                                        }
+                                        
                                         return (
                                             <SVGText
                                                 originY={ y(value) }
@@ -139,7 +146,7 @@ class YAxis extends PureComponent {
                                                 key={ y(value) }
                                                 y={ y(value) }
                                             >
-                                                {formatLabel(value, index, ticks.length)}
+                                                {label}
                                             </SVGText>
                                         )
                                     })


### PR DESCRIPTION
In [issue #332](https://github.com/JesperLekland/react-native-svg-charts/issues/332) I had a problem with too many views being rendered. This PR helped reducing the amount of rendered views by not rendering text that contain no text. Even though they wouldn't render to anything, there was still a serialisation cost going over the bridge, so this helped me some