### PR TITLE
Fix YAxis using Unnecessary max/min value before definition

### DIFF
--- a/src/y-axis.js
+++ b/src/y-axis.js
@@ -72,7 +72,7 @@ class YAxis extends PureComponent {
 
         const values = data.map((item, index) => yAccessor({ item, index }))
 
-        const extent = array.extent([ ...values, min, max ])
+        const extent = array.extent(values)
 
         const {
             min = extent[0],


### PR DESCRIPTION
fixes #335 

https://github.com/JesperLekland/react-native-svg-charts/blob/d5c600d9a11a7cf10bd0b6b73a172b854e90dcdf/src/y-axis.js#L75
In this line, `min` and `max` are used before they are defined.  As @tonypee says in #335, these min/max are `undefined` and ignored by the `.extent()`.  So I see no problem when I use it on iOS / Android Simulator(and maybe also on real machines). But I got an error when I use it in Storybook with react-native-web and [svgs](https://github.com/godaddy/svgs). ↓like this
```
Cannot access 'min' before initialization
ReferenceError: Cannot access 'min' before initialization
    at YAxis.render (http://localhost:9001/vendors~main.7f9b4aa8c2e8d95c391b.hot-update.js:12885:80)
    ...
```
Therefore I deleted `min` and `max`.
I believe this change makes no troubles and no behavior-changes.