### PR TITLE
prevent crash on undefined data

### DIFF
--- a/src/bar-chart/index.js
+++ b/src/bar-chart/index.js
@@ -5,7 +5,7 @@ import BarChartGrouped from './bar-chart-grouped'
 const BarChartGate = (props) => {
     const { data } = props
 
-    if (data[ 0 ].hasOwnProperty('data')) {
+    if (data[0] && data[ 0 ].hasOwnProperty('data')) {
         return <BarChartGrouped { ...props }/>
     }
 

--- a/src/line-chart/index.js
+++ b/src/line-chart/index.js
@@ -5,7 +5,7 @@ import LineChartGrouped from './line-chart-grouped'
 const LineChartGate = (props) => {
     const { data } = props
 
-    if (data[0].hasOwnProperty('data')) {
+    if (data[0] && data[0].hasOwnProperty('data')) {
         return <LineChartGrouped { ...props } />
     }
 

--- a/src/stacked-bar-chart/index.js
+++ b/src/stacked-bar-chart/index.js
@@ -5,7 +5,7 @@ import StackedBarChartGrouped from './stacked-bar-grouped'
 const StackedBarChartGate = props => {
     const { data } = props
 
-    if (data[0].hasOwnProperty('data')) {
+    if (data[0] && data[0].hasOwnProperty('data')) {
         return <StackedBarChartGrouped { ...props } />
     }
 


### PR DESCRIPTION
### Issue

### Test scenario
For: `<BarChart />, <LineChart />, <StackedBarChart />` provide data as follow:
```
const data = [undefined, 10, 15, 0];
```
This would previously throw an error: `Type error: Can not read property 'hasOwnProperty' of undefined`