### PR TITLE
Added prevention of blocking touch events in stacked pie-chart

### DIFF
--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -125,15 +125,10 @@ class PieChart extends PureComponent {
         }
 
         return (
-            <View
-                pointerEvents={ 'box-none' }
-                style={style}>
-                <View
-                    pointerEvents={ 'box-none' }
-                    style={{ flex: 1 }}
-                    onLayout={(event) => this._onLayout(event)}>
+            <View pointerEvents={'box-none'} style={style}>
+                <View pointerEvents={'box-none'} style={{ flex: 1 }} onLayout={(event) => this._onLayout(event)}>
                     {height > 0 && width > 0 && (
-                        <Svg style={{ height, width }}>
+                        <Svg pointerEvents={'box-none'} style={{ height, width }}>
                             {/* center the progress circle*/}
                             <G x={width / 2} y={height / 2}>
                                 {React.Children.map(children, (child) => {

--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -125,8 +125,13 @@ class PieChart extends PureComponent {
         }
 
         return (
-            <View style={style}>
-                <View style={{ flex: 1 }} onLayout={(event) => this._onLayout(event)}>
+            <View
+                pointerEvents={ 'box-none' }
+                style={style}>
+                <View
+                    pointerEvents={ 'box-none' }
+                    style={{ flex: 1 }}
+                    onLayout={(event) => this._onLayout(event)}>
                     {height > 0 && width > 0 && (
                         <Svg style={{ height, width }}>
                             {/* center the progress circle*/}

--- a/src/pie-chart.js
+++ b/src/pie-chart.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react'
-import { View } from 'react-native'
+import { View, Platform } from 'react-native'
 import PropTypes from 'prop-types'
 import * as shape from 'd3-shape'
 import Svg, { G, Path } from 'react-native-svg'
@@ -128,7 +128,7 @@ class PieChart extends PureComponent {
             <View pointerEvents={'box-none'} style={style}>
                 <View pointerEvents={'box-none'} style={{ flex: 1 }} onLayout={(event) => this._onLayout(event)}>
                     {height > 0 && width > 0 && (
-                        <Svg pointerEvents={'box-none'} style={{ height, width }}>
+                        <Svg pointerEvents={Platform.OS === 'android' && 'box-none'} style={{ height, width }}>
                             {/* center the progress circle*/}
                             <G x={width / 2} y={height / 2}>
                                 {React.Children.map(children, (child) => {


### PR DESCRIPTION
The hit area of a View is mostly a square. When stacking 2 pie-charts on top of each other, the square hit area of the top chart is blocking the bottom chart from receiving touch events. By adding the 'pointerEvents={'box-none'}' to the container Views, the touch events are passed through the chart underneath.
![Screenshot 2019-08-06 at 08 25 54](https://user-images.githubusercontent.com/39825539/62515994-29bb8780-b824-11e9-9fe2-42785b73ce7c.png)
