### PR TITLE
fix: avoid warning of unrecognized props

### DIFF
--- a/src/animated-path.js
+++ b/src/animated-path.js
@@ -80,11 +80,13 @@ class AnimatedPath extends Component {
     }
 
     render() {
+        const { animate, animationDuration, renderPlaceholder, ...rest } = this.props
+        
         return (
             <Path
                 ref={(ref) => (this.component = ref)}
-                {...this.props}
-                d={this.props.animate ? this.state.d : this.props.d}
+                {...rest}
+                d={animate ? this.state.d : this.props.d}
             />
         )
     }


### PR DESCRIPTION
Currently, the `Path` component generates warnings like these on web:
```
Warning: Received `false` for a non-boolean attribute `animate`.

If you want to write it to the DOM, pass a string instead: animate="false" or animate={value.toString()}.

If you used to conditionally omit it with animate={condition && value}, pass animate={condition ? value : undefined} instead.
```

```
Warning: React does not recognize the `animationDuration` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `animationduration` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

```
Warning: React does not recognize the `renderPlaceholder` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `renderplaceholder` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

This PR removes the props before passing them on to the actual `Path`.