### PR TITLE
Fix YAxis & XAxis height & width when using custom fontFamily and/or fontWeight

### DIFF
--- a/src/x-axis.js
+++ b/src/x-axis.js
@@ -75,7 +75,16 @@ class XAxis extends PureComponent {
             <View style={style}>
                 <View style={{ flexGrow: 1 }} onLayout={(event) => this._onLayout(event)}>
                     {/*invisible text to allow for parent resizing*/}
-                    <Text style={{ opacity: 0, fontSize: svg.fontSize }}>{formatLabel(ticks[0], 0)}</Text>
+                    <Text
+                        style={{
+                            opacity: 0,
+                            fontSize: svg.fontSize,
+                            fontFamily: svg.fontFamily,
+                            fontWeight: svg.fontWeight,
+                        }}
+                    >
+                        {formatLabel(ticks[0], 0)}
+                    </Text>
                     {height > 0 && width > 0 && (
                         <Svg
                             style={{

--- a/src/y-axis.js
+++ b/src/y-axis.js
@@ -88,7 +88,16 @@ class YAxis extends PureComponent {
             <View style={[style]}>
                 <View style={{ flexGrow: 1 }} onLayout={(event) => this._onLayout(event)}>
                     {/*invisible text to allow for parent resizing*/}
-                    <Text style={{ opacity: 0, fontSize: svg.fontSize }}>{longestValue}</Text>
+                    <Text
+                        style={{
+                            opacity: 0,
+                            fontSize: svg.fontSize,
+                            fontFamily: svg.fontFamily,
+                            fontWeight: svg.fontWeight,
+                        }}
+                    >
+                        {longestValue}
+                    </Text>
                     {height > 0 && width > 0 && (
                         <Svg
                             style={{


### PR DESCRIPTION
The invisible `<Text/>` component used to calculate width wasn't taking into consideration `fontFamily` or `fontWeight` so it was getting clipped. This doesn't change anything if you don't specify either option. 

Before:

![image](https://user-images.githubusercontent.com/206295/63119685-1c667180-bf77-11e9-8a5f-bf01eac108eb.png)

After:

![image](https://user-images.githubusercontent.com/206295/63119760-4029b780-bf77-11e9-991d-6d6561257cc7.png)

Without custom font (no change):

![image](https://user-images.githubusercontent.com/206295/63119822-5d5e8600-bf77-11e9-9a77-a3d9ce8a6fb8.png)
