### PR TITLE
Fix a bug: animations for grouped LineChart were not working

### DIFF
--- a/src/chart/chart-grouped.js
+++ b/src/chart/chart-grouped.js
@@ -110,7 +110,7 @@ class ChartGrouped extends PureComponent {
                                 const { svg: pathSvg } = data[index]
                                 return (
                                     <Path
-                                        key={path}
+                                        key={index}
                                         fill={'none'}
                                         {...svg}
                                         {...pathSvg}


### PR DESCRIPTION
The reason of a problem was that the paths themselves were passed as keys. Thus the keys of react nodes were changed and nodes were remounted, and componentDidUpdate method of animated-path component was not fired. This small fix resolves this issue.