### PR TITLE
fixing scale PropType to PropTypes.func to be able to use custom scales

### DIFF
--- a/src/x-axis.js
+++ b/src/x-axis.js
@@ -128,7 +128,7 @@ XAxis.propTypes = {
         left: PropTypes.number,
         right: PropTypes.number,
     }),
-    scale: PropTypes.oneOf([d3Scale.scaleTime, d3Scale.scaleLinear, d3Scale.scaleBand]),
+    scale: PropTypes.func,
     numberOfTicks: PropTypes.number,
     xAccessor: PropTypes.func,
     svg: PropTypes.object,


### PR DESCRIPTION
Hi!
I was trying to make "nice" scaleTime axis for XAxis:
<XAxis
....
scale={() => {
                return scaleTime().nice(timeMonth);
           }}
/>
 and got warning about invalid proptype.

Also I found that YAxis scale and Chart xScale, yScale - they all have PropTypes.func as proptype