### PR TITLE
fix(grid): link vertical grid to ticks on the x axis

### DIFF
--- a/src/grid.js
+++ b/src/grid.js
@@ -5,7 +5,7 @@ import { G, Line } from 'react-native-svg'
 const Horizontal = ({ ticks = [], y, svg }) => {
     return (
         <G>
-            {ticks.map((tick) => (
+            {y.ticks(ticks.length).map((tick) => (
                 <Line
                     key={tick}
                     x1={'0%'}
@@ -24,7 +24,7 @@ const Horizontal = ({ ticks = [], y, svg }) => {
 const Vertical = ({ ticks = [], x, svg }) => {
     return (
         <G>
-            {ticks.map((tick, index) => (
+            {x.ticks(ticks.length).map((tick, index) => (
                 <Line
                     key={index}
                     y1={'0%'}


### PR DESCRIPTION
At the moment `<Grid direction={Grid.Direction.VERTICAL}/>` doesn't render anything as it's referring to the points on the Y axis.
This change, updates both `Horizontal` and `Vertical` components so the ticks are related to their respective axis, and, at the same time, honours the `numberOfTicks` property by limiting it to `ticks.length`